### PR TITLE
feat(casing): add new casing setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ If a folder is named after a routing keyword (`server`, `client`, `shared`) or a
 ### 2. Marker File
 To route a folder, you can also place an empty marker file (e.g., `.server`, `.client`, `.shared`) directly inside the directory.
 * **Behavior:** The entire folder is routed to that service, but the folder's name is preserved in the Roblox tree.
-* **Example:** A folder named `AntiCheat` containing a `.server` marker file will be routed to `ServerScriptService/server/AntiCheat`.
+* **Example:** With the default `camelCase` setting, a folder named `AntiCheat` containing a `.server` marker file will be routed to `ServerScriptService/server/antiCheat`.
 
 ### 3. File Name
 To route a specific file differently than its parent folder, use a routing prefix or suffix. File affixes are absolute and will always override folder names and marker files.
@@ -39,7 +39,7 @@ To route a specific file differently than its parent folder, use a routing prefi
 * **CamelCase & PascalCase:** Prepend or append the mapped keyword directly to the filename.
 	* **Examples:** inputClient.ts, serverData.ts
 
-**Note:** *By default, Rogen strips the routing keyword from the final module name (e.g., `serverData.ts` and `data.server.ts` become `Data` and `data`, respectively). You can disable this behavior using the `--keepRouteNames` flag*.
+**Note:** *By default, Rogen strips the routing keyword from the final module name (e.g., `serverData.ts` and `data.server.ts` both become `data`). You can disable this behavior using the `--keepRouteNames` flag*.
 
 ### 4. Default Fallback
 If no routing rules or keywords are found anywhere in the path, the file defaults to `ReplicatedStorage`.
@@ -73,6 +73,7 @@ Here is a default configuration structure that works for both roblox-ts and luau
 ```json
 {
 	"source": ["src"],
+	"casing": "camelCase",
 	"keepRouteNames": false,
 	"luau": { 
 		"output": "default.project.json", 
@@ -122,9 +123,12 @@ Here is a default configuration structure that works for both roblox-ts and luau
 }
 ```
 
+The `casing` setting accepts `"PascalCase"` or `"camelCase"` and defaults to `"camelCase"`. For example, `src/features/test/testServiceUtils.luau` is generated under `ReplicatedStorage/Shared/Features/Test/TestServiceUtils` with `"PascalCase"`, or under `ReplicatedStorage/shared/features/test/testServiceUtils` with `"camelCase"`.
+
 | Property            | Description                                                                                                                                                                                                                                                         |
 | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | source              | The root directory (String) or directories (Array of Strings) where your source code lives (defaults to "src"). Passing an array allows you to merge multiple source folders into a single tree.                                                                                                                                                                                    |
+| casing              | Controls generated folder and script-name casing. Accepted values are `"PascalCase"` and `"camelCase"`; defaults to `"camelCase"`. |
 | luau / ts / darklua  | Mode-specific overrides. Rogen uses these to dictate where the compiled code ends up (build) and the name of the generated Rojo file (output)                                                                                                                       |
 | <custom_mode>  | You can define your own custom pipeline modes (e.g., "lute") by adding a new key. Custom modes must include an output and a build value.                                                                                                                       |
 | template            | The base Rojo tree template. Any standard Rojo `default.project.json` fields (like `name`, `globIgnorePaths`, or a custom `tree`) placed here will be safely merged with Rogen's auto-generated paths. You can also specify a path to a JSON file with a Rojo tree! |

--- a/examples/roblox-luau-app/.rogen.json
+++ b/examples/roblox-luau-app/.rogen.json
@@ -1,5 +1,6 @@
 {
 	"source": ["src"],
+	"casing": "PascalCase",
 	"keepRouteNames": false,
 	"luau": { 
 		"output": "default.project.json", 

--- a/examples/roblox-ts-app/.rogen.json
+++ b/examples/roblox-ts-app/.rogen.json
@@ -1,5 +1,6 @@
 {
 	"source": ["src"],
+	"casing": "camelCase",
 	"keepRouteNames": false,
 	"luau": { 
 		"output": "default.project.json", 

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,7 +42,7 @@ export function loadAndValidateConfig(configPath: string | null): { config: Roge
 	}
 
 	const config = JSON.parse(fs.readFileSync(configPath, "utf-8")) as RogenConfig;
-	const standardKeys = ["source", "template", "luau", "ts", "darklua", "aliases", "keepRouteNames"];
+	const standardKeys = ["source", "template", "luau", "ts", "darklua", "aliases", "keepRouteNames", "casing"];
 
 	for (const key in config) {
 		if (!standardKeys.includes(key)) {
@@ -64,8 +64,11 @@ export function loadAndValidateConfig(configPath: string | null): { config: Roge
 			throw new Error(`\nConfiguration Error: 'template' must be an inline object or a string path to a JSON file.\n`);
 		} else if (key === "keepRouteNames" && typeof config[key] !== "boolean") {
 			throw new Error(`\nConfiguration Error: 'keepRouteNames' must be a boolean.\n`);
+		} else if (key === "casing" && config[key] !== "PascalCase" && config[key] !== "camelCase") {
+			throw new Error(`\nConfiguration Error: 'casing' must be either "PascalCase" or "camelCase".\n`);
 		}
 	}
+	config.casing ??= "camelCase";
 
 	return { config, hasConfig: true };
 }
@@ -102,12 +105,14 @@ export function getEnvironment(): Environment {
 
 export function resolveActiveModes(config: RogenConfig, hasConfig: boolean, cliMode: string | undefined, env: Environment): RogenMode[] {
 	const baseLanguage = env.isTsProject ? (config.ts || defaultConfig.ts!) : (config.luau || defaultConfig.luau!);
-	const nonModeKeys = new Set(["source", "template", "aliases", "keepRouteNames"]);
+	const nonModeKeys = new Set(["source", "template", "aliases", "keepRouteNames", "casing"]);
 	const activeModes: RogenMode[] = [];
 
 	if (hasConfig) {
 		if (cliMode) {
-			if (!config[cliMode]) throw new Error(`Mode "${cliMode}" is not defined in your config file.`);
+			if (nonModeKeys.has(cliMode) || !config[cliMode]) {
+				throw new Error(`Mode "${cliMode}" is not defined in your config file.`);
+			}
 			activeModes.push(config[cliMode] as RogenMode);
 		} else {
 			for (const key in config) {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,6 +3,7 @@ import { RogenConfig, RoutingMaps } from "./types.js";
 export const defaultConfig: RogenConfig = {
 	source: ["src"],
 	keepRouteNames: false,
+	casing: "camelCase",
 	aliases: {},
 	luau: { 
 		output: "default.project.json", 

--- a/src/core/build.ts
+++ b/src/core/build.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
 import path from "path";
-import { getOrCreateNode, pruneObject, sortObject, findMissingPaths } from "./tree.js";
+import { applyCasing, getOrCreateNode, pruneObject, sortObject, findMissingPaths } from "./tree.js";
 import { resolveRoute } from "./route.js";
 import { serviceParents, generateRoutingMaps } from "../constants.js";
 import { BuildResult, CliArgs, Environment, RogenConfig, RogenMode, RojoNode, RojoTree, RouteContext, RoutingMaps } from "../types.js";
@@ -66,6 +66,7 @@ export function build(
 
 	const rojoTree: RojoTree = JSON.parse(JSON.stringify(baseProjectTree));
 	rojoTree.tree = rojoTree.tree || { $className: "DataModel" };
+	const casing = config.casing ?? "camelCase";
 
 	const context: RouteContext = {
 		source: config.source || "src",
@@ -106,20 +107,21 @@ export function build(
 				current = getOrCreateNode(current, serviceParents[targetService]);
 			}
 			current = getOrCreateNode(current, targetService);
-			current = getOrCreateNode(current, wrapperFolder, "Folder");
+			current = getOrCreateNode(current, applyCasing(wrapperFolder, casing), "Folder");
 
 			for (const part of virtualParts) {
-				current = getOrCreateNode(current, part, "Folder");
+				current = getOrCreateNode(current, applyCasing(part, casing), "Folder");
 			}
 
-			const existingNode = (current[nodeName] as RojoNode) || {};
+			const casedNodeName = applyCasing(nodeName, casing);
+			const existingNode = (current[casedNodeName] as RojoNode) || {};
 			const newNode: RojoNode = { ...existingNode, $path: projectPath };
 			
 			if (newNode.$className === "Folder") {
 				delete newNode.$className;
 			}
 			
-			current[nodeName] = newNode;
+			current[casedNodeName] = newNode;
 		});
 	}
 

--- a/src/core/tree.ts
+++ b/src/core/tree.ts
@@ -1,8 +1,18 @@
 import fs from "fs";
 import path from "path";
-import { MissingPath, RojoNode } from "../types.js";
+import { Casing, MissingPath, RojoNode } from "../types.js";
 
 export const toPosix = (p: string): string => p.split(path.sep).join("/");
+
+export function applyCasing(value: string, casing: Casing): string {
+	if (value.length === 0) return value;
+
+	const firstCharacter = casing === "PascalCase"
+		? value[0].toUpperCase()
+		: value[0].toLowerCase();
+
+	return firstCharacter + value.slice(1);
+}
 
 export function getOrCreateNode(parent: RojoNode, key: string, className?: string): RojoNode {
 	if (!parent[key]) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,9 +16,12 @@ export interface RogenMode {
 	build: string;
 }
 
+export type Casing = "PascalCase" | "camelCase";
+
 export interface RogenConfig {
 	source?: string | string[];
 	keepRouteNames?: boolean;
+	casing?: Casing;
 	aliases?: Record<string, string>;
 	luau?: RogenMode;
 	ts?: RogenMode;

--- a/tests/build.test.ts
+++ b/tests/build.test.ts
@@ -54,11 +54,11 @@ describe("Builder Integration", () => {
 		expect(result.buildDir).toBe("out");
 		expect(result.output).toBe("test.project.json");
 
-		expect(resultTree.ServerScriptService.server.systems.Combat).toBeDefined();
-		expect(resultTree.ServerScriptService.server.systems.Combat.$path).toBe("out/systems/Combat.server.lua");
+		expect(resultTree.ServerScriptService.server.systems.combat).toBeDefined();
+		expect(resultTree.ServerScriptService.server.systems.combat.$path).toBe("out/systems/Combat.server.lua");
 
-		expect(resultTree.ReplicatedStorage.shared.Weapon).toBeDefined();
-		expect(resultTree.ReplicatedStorage.shared.Weapon.$path).toBe("out/Weapon.rbxm");
+		expect(resultTree.ReplicatedStorage.shared.weapon).toBeDefined();
+		expect(resultTree.ReplicatedStorage.shared.weapon.$path).toBe("out/Weapon.rbxm");
 
 		expect(resultTree.ReplicatedStorage.shared.ui).toBeDefined();
 		expect(resultTree.ReplicatedStorage.shared.ui.$path).toBe("out/ui");
@@ -96,11 +96,11 @@ describe("Builder Integration", () => {
 
 		expect(result.fileCount).toBe(2); 
 
-		expect(resultTree.ReplicatedStorage.shared.CoreMath).toBeDefined();
-		expect(resultTree.ReplicatedStorage.shared.LevelData).toBeDefined();
+		expect(resultTree.ReplicatedStorage.shared.coreMath).toBeDefined();
+		expect(resultTree.ReplicatedStorage.shared.levelData).toBeDefined();
 		
-		expect(resultTree.ReplicatedStorage.shared.CoreMath.$path).toBe("out/core/CoreMath.lua");
-		expect(resultTree.ReplicatedStorage.shared.LevelData.$path).toBe("out/chapter1/LevelData.lua");
+		expect(resultTree.ReplicatedStorage.shared.coreMath.$path).toBe("out/core/CoreMath.lua");
+		expect(resultTree.ReplicatedStorage.shared.levelData.$path).toBe("out/chapter1/LevelData.lua");
 	});
 
 	it("should route files based on marker files instead of folder names", () => {
@@ -136,7 +136,85 @@ describe("Builder Integration", () => {
 
 		expect(result.fileCount).toBe(1); 
 		
-		expect(resultTree.ServerScriptService.server.Database.query).toBeDefined();
-		expect(resultTree.ServerScriptService.server.Database.query.$path).toBe("out/Database/query.lua");
+		expect(resultTree.ServerScriptService.server.database.query).toBeDefined();
+		expect(resultTree.ServerScriptService.server.database.query.$path).toBe("out/Database/query.lua");
+	});
+
+	it("should generate PascalCase tree names without changing source paths", () => {
+		jest.spyOn(fs, "existsSync").mockReturnValue(true);
+
+		(jest.spyOn(fs, "readdirSync") as jest.Mock<(dir: string) => any[]>).mockImplementation((dir: string) => {
+			const normalizedDir = String(dir).replace(/\\/g, "/");
+
+			if (normalizedDir.endsWith("src")) {
+				return [
+					{ name: "features", isDirectory: () => true, isFile: () => false }
+				] as fs.Dirent[];
+			}
+
+			if (normalizedDir.endsWith("features")) {
+				return [
+					{ name: "test", isDirectory: () => true, isFile: () => false }
+				] as fs.Dirent[];
+			}
+
+			if (normalizedDir.endsWith("test")) {
+				return [
+					{ name: "testServiceUtils.luau", isDirectory: () => false, isFile: () => true }
+				] as fs.Dirent[];
+			}
+
+			return [];
+		});
+
+		const targetConfig: RogenMode = { build: "out", output: "test.project.json" };
+		const baseTree: RojoTree = { name: "test-game", tree: {} };
+		const config: RogenConfig = { source: "src", casing: "PascalCase" };
+		const env: Environment = { isTsProject: false, isDarkluaProject: false };
+
+		const result = build(targetConfig, baseTree, config, env, ["src"], {});
+		const node = (result.tree.tree as any).ReplicatedStorage.Shared.Features.Test.TestServiceUtils;
+
+		expect(node).toBeDefined();
+		expect(node.$path).toBe("out/features/test/testServiceUtils.luau");
+	});
+
+	it("should generate camelCase tree names by default without changing source paths", () => {
+		jest.spyOn(fs, "existsSync").mockReturnValue(true);
+
+		(jest.spyOn(fs, "readdirSync") as jest.Mock<(dir: string) => any[]>).mockImplementation((dir: string) => {
+			const normalizedDir = String(dir).replace(/\\/g, "/");
+
+			if (normalizedDir.endsWith("src")) {
+				return [
+					{ name: "Features", isDirectory: () => true, isFile: () => false }
+				] as fs.Dirent[];
+			}
+
+			if (normalizedDir.endsWith("Features")) {
+				return [
+					{ name: "Test", isDirectory: () => true, isFile: () => false }
+				] as fs.Dirent[];
+			}
+
+			if (normalizedDir.endsWith("Test")) {
+				return [
+					{ name: "TestServiceUtils.luau", isDirectory: () => false, isFile: () => true }
+				] as fs.Dirent[];
+			}
+
+			return [];
+		});
+
+		const targetConfig: RogenMode = { build: "out", output: "test.project.json" };
+		const baseTree: RojoTree = { name: "test-game", tree: {} };
+		const config: RogenConfig = { source: "src" };
+		const env: Environment = { isTsProject: false, isDarkluaProject: false };
+
+		const result = build(targetConfig, baseTree, config, env, ["src"], {});
+		const node = (result.tree.tree as any).ReplicatedStorage.shared.features.test.testServiceUtils;
+
+		expect(node).toBeDefined();
+		expect(node.$path).toBe("out/Features/Test/TestServiceUtils.luau");
 	});
 });

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -1,9 +1,41 @@
-import { resolveActiveModes } from "../src/config.js";
+import fs from "fs";
+import { jest } from "@jest/globals";
+import { loadAndValidateConfig, resolveActiveModes } from "../src/config.js";
 import { defaultConfig } from "../src/constants.js";
 import { Environment, RogenConfig } from "../src/types.js";
 
 describe("Configuration Resolution", () => {
 	const defaultEnv: Environment = { isTsProject: false, isDarkluaProject: false };
+
+	afterEach(() => {
+		jest.restoreAllMocks();
+	});
+
+	function mockConfigFile(config: Record<string, unknown>): void {
+		jest.spyOn(fs, "readFileSync").mockReturnValue(JSON.stringify(config));
+	}
+
+	it("should default casing to camelCase", () => {
+		expect(defaultConfig.casing).toBe("camelCase");
+
+		mockConfigFile({ luau: { build: "src", output: "default.project.json" } });
+		expect(loadAndValidateConfig("test.rogen.json").config.casing).toBe("camelCase");
+	});
+
+	it.each(["PascalCase", "camelCase"] as const)("should accept %s casing", (casing) => {
+		mockConfigFile({ casing });
+
+		const result = loadAndValidateConfig("test.rogen.json");
+
+		expect(result.hasConfig).toBe(true);
+		expect(result.config.casing).toBe(casing);
+	});
+
+	it.each(["pascalCase", "snake_case", true, null])("should reject unsupported casing value %p", (casing) => {
+		mockConfigFile({ casing });
+
+		expect(() => loadAndValidateConfig("test.rogen.json")).toThrow(/casing/i);
+	});
 
 	it("should fallback to luau if no config exists and environment is standard", () => {
 		const modes = resolveActiveModes({}, false, undefined, defaultEnv);
@@ -25,6 +57,14 @@ describe("Configuration Resolution", () => {
 		expect(() => {
 			resolveActiveModes(customConfig, true, "nonExistentMode", defaultEnv);
 		}).toThrow('Mode "nonExistentMode" is not defined in your config file.');
+	});
+
+	it("should not treat casing as an output mode", () => {
+		const customConfig: RogenConfig = { casing: "PascalCase" };
+
+		expect(() => {
+			resolveActiveModes(customConfig, true, "casing", defaultEnv);
+		}).toThrow('Mode "casing" is not defined in your config file.');
 	});
 
 	it("should successfully load a custom CLI mode", () => {

--- a/tests/tree.test.ts
+++ b/tests/tree.test.ts
@@ -1,6 +1,6 @@
 import fs from "fs";
-import { getOrCreateNode, sortObject, pruneObject } from "../src/core/tree.js";
-import { RojoNode } from "../src/types.js";
+import { applyCasing, getOrCreateNode, sortObject, pruneObject } from "../src/core/tree.js";
+import { Casing, RojoNode } from "../src/types.js";
 import { jest } from "@jest/globals";
 
 describe("Tree Utilities", () => {
@@ -21,6 +21,28 @@ describe("Tree Utilities", () => {
 			const result = getOrCreateNode(parent, "MyFolder", "Folder");
 			expect(result).toEqual({ $path: "src/MyFolder" });
 		});
+	});
+
+	describe("applyCasing", () => {
+		it("should uppercase the first character for PascalCase", () => {
+			expect(applyCasing("testServiceUtils", "PascalCase")).toBe("TestServiceUtils");
+		});
+
+		it("should lowercase the first character for camelCase", () => {
+			expect(applyCasing("TestServiceUtils", "camelCase")).toBe("testServiceUtils");
+		});
+
+		it("should preserve capitalization after the first character", () => {
+			expect(applyCasing("testHTTPService", "PascalCase")).toBe("TestHTTPService");
+			expect(applyCasing("TestHTTPService", "camelCase")).toBe("testHTTPService");
+		});
+
+		it.each<Casing>(["PascalCase", "camelCase"])(
+			"should return an empty string for %s",
+			(casing) => {
+				expect(applyCasing("", casing)).toBe("");
+			}
+		);
 	});
 
 	describe("sortObject", () => {


### PR DESCRIPTION
This pull request adds support for configurable casing of generated folder and script names in the Rojo tree, allowing users to choose between `"camelCase"` and `"PascalCase"` via the new `casing` option in `.rogen.json`. The default is now `"camelCase"`. The codebase, documentation, and tests have been updated to reflect and validate this new setting.

**Casing configuration and validation:**
- Added a `casing` option to the config schema, with validation to accept only `"PascalCase"` or `"camelCase"`, defaulting to `"camelCase"` if not specified. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L45-R45) [[2]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012R67-R71) [[3]](diffhunk://#diff-c54113cf61ec99691748a3890bfbeb00e10efb3f0a76f03a0fd9ec49072e410aR19-R24) [[4]](diffhunk://#diff-8fa4b52909f895e8cda060d2035234e0a42ca2c7d3f8f8de1b35a056537bf199R6)
- Updated example `.rogen.json` files to demonstrate both casing options. [[1]](diffhunk://#diff-60e5e6d2bb14edce15545d60c773e38f3afafd8882dd2f00aadeebe904b488c0R3) [[2]](diffhunk://#diff-bfbf249ab28bb8f9753cd10822b978a3ce14c335f33bb7f2ff2e474d2b86fe42R3)

**Core build logic:**
- Introduced the `applyCasing` utility and integrated it into the tree generation logic so that all generated folder and script names use the configured casing, without affecting the underlying source file paths. [[1]](diffhunk://#diff-86b0ff22c7aeb11adbbef0fb434680f643f61393d84eb71b7f270002e4fc2c23L3-R3) [[2]](diffhunk://#diff-86b0ff22c7aeb11adbbef0fb434680f643f61393d84eb71b7f270002e4fc2c23R69) [[3]](diffhunk://#diff-86b0ff22c7aeb11adbbef0fb434680f643f61393d84eb71b7f270002e4fc2c23L109-R124) [[4]](diffhunk://#diff-9bf0958f47f75f51a2c4654cfd85b6d956e804a1f2f39b4bf1f7942d3d7972a0L3-R16)

**Documentation updates:**
- Updated the `README.md` to document the new `casing` option, including examples and explanations of how casing affects the generated output. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L33-R33) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L42-R42) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R76) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R126-R131)

**Tests:**
- Added and updated integration and unit tests to verify correct casing behavior in both the build output and configuration validation. [[1]](diffhunk://#diff-960d048eb56e9979dd07af91af750794ccd46c1b6367463727c7a9c7a0173a1fL57-R61) [[2]](diffhunk://#diff-960d048eb56e9979dd07af91af750794ccd46c1b6367463727c7a9c7a0173a1fL99-R103) [[3]](diffhunk://#diff-960d048eb56e9979dd07af91af750794ccd46c1b6367463727c7a9c7a0173a1fL139-R218) [[4]](diffhunk://#diff-9b210bb9fcd3e28a36905f0c8347fbc8fa201f51fa66e27f51dcf7443b058562L1-R39) [[5]](diffhunk://#diff-9b210bb9fcd3e28a36905f0c8347fbc8fa201f51fa66e27f51dcf7443b058562R62-R69) [[6]](diffhunk://#diff-7b64722d213f1517c8a8bf9a267cb132697217092381413311ba0cfe76c171fbL2-R3) [[7]](diffhunk://#diff-7b64722d213f1517c8a8bf9a267cb132697217092381413311ba0cfe76c171fbR26-R47)

**Config and mode handling:**
- Ensured that the new `casing` option is not treated as a build mode and is excluded from mode resolution logic. [[1]](diffhunk://#diff-c3095d5010e65c52737a98a5d618ea24049ebe90c8470752426081d70ed6e012L105-R115) [[2]](diffhunk://#diff-9b210bb9fcd3e28a36905f0c8347fbc8fa201f51fa66e27f51dcf7443b058562R62-R69)